### PR TITLE
Adding an index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+var fs = require('fs')
+
+module.exports = {
+    getPageStrategyElement: function(pageStrategy, element) {
+        if (!fs.existsSync(__dirname + '/' + pageStrategy + '/' + element)) {
+            return {
+                noSuchStrategy: "file does not exist: " + __dirname + '/' + pageStrategy + '/' + element
+            }
+        }
+        var pageStrategyPath = __dirname + '/' + pageStrategy + '/' + element;
+        return {
+            data: fs.readFileSync(pageStrategyPath).toString()
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "1.0.0",
   "description": "Page Strategies for BBC TAL",
   "main": "index.js",
+  "directories": {
+    "default": "./default",
+    "hbbtv": "./hbbtv",
+    "html5hbbtvhybrid": "./html5hbbtvhybrid",
+    "htmlbroadcastvideo": "./htmlbroadcastvideo",
+    "samsungmaple": "./samsungmaple"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The TAL Launcher is not compatible with node v5+
In order for it to be fixed it should be looking for node modules like it is
[strategist.js](https://github.com/fmtvp/library-tal-launcher/blob/e86f7fda95cd11bb9b38834f78d49d761ceb4890/lib/indexPage/strategist.js) line 24
This means the function ``readValueFromFile` can be replaced with requiring this instead
See [PR](https://github.com/fmtvp/library-tal-launcher/pull/54) for how I am proposing to use it
