### PR TITLE
page strategy required to allow Live seeking for set of samsung devices

### DIFF
--- a/samsungstreaming/body
+++ b/samsungstreaming/body
@@ -1,0 +1,6 @@
+  <object id='sefPlayer' border='0' classid='clsid:SAMSUNG-INFOLINK-SEF' style='position: fixed; top: 0px; left: 0px'></object>
+  <object id='audioPlugin' border='0' classid='clsid:SAMSUNG-INFOLINK-AUDIO' style='position: absolute'></object>
+  <object id='pluginObjectTV' border='0' classid='clsid:SAMSUNG-INFOLINK-TV' style='position: absolute'></object>
+  <object id='pluginObjectTVMW' border='0' classid='clsid:SAMSUNG-INFOLINK-TVMW' style='position: absolute'></object>
+  <object id='pluginObjectNNavi' border='0' classid='clsid:SAMSUNG-INFOLINK-NNAVI' style='position: absolute'></object>
+  <object id='pluginObjectWindow' border='0' classid='clsid:SAMSUNG-INFOLINK-WINDOW' style='visibility:hidden; position:absolute; opacity: 0.0; width: 0; height: 0'></object>

--- a/samsungstreaming/header
+++ b/samsungstreaming/header
@@ -1,0 +1,4 @@
+  <script type="text/javascript" language="javascript" src="$MANAGER_WIDGET/Common/API/Widget.js"></script>
+  <script type="text/javascript" language="javascript" src="$MANAGER_WIDGET/Common/API/TVKeyValue.js"></script>
+  <script type="text/javascript" language="javascript" src="$MANAGER_WIDGET/Common/API/Plugin.js"></script>
+  <script type="text/javascript" language="javascript" src="$MANAGER_WIDGET/Common/webapi/1.0/webapis.js"/></script>


### PR DESCRIPTION
This is the page strategy for the family of X14 devices that are able to do live seeking as functionality developed by partner