### PR TITLE
IPLAYERTVV1-9564 add utf-8 charset

### DIFF
--- a/default/mimetype
+++ b/default/mimetype
@@ -1,1 +1,1 @@
-text/html
+text/html; charset=utf-8

--- a/hbbtv/mimetype
+++ b/hbbtv/mimetype
@@ -1,1 +1,1 @@
-application/vnd.hbbtv.xhtml+xml
+application/vnd.hbbtv.xhtml+xml; charset=utf-8

--- a/hbbtv141/mimetype
+++ b/hbbtv141/mimetype
@@ -1,1 +1,1 @@
-application/vnd.hbbtv.xhtml+xml
+application/vnd.hbbtv.xhtml+xml; charset=utf-8

--- a/uwp/mimetype
+++ b/uwp/mimetype
@@ -1,1 +1,1 @@
-text/html
+text/html; charset=utf-8


### PR DESCRIPTION
We believe IPLAYERTVV1-9564 is caused by a lack of explicit UTF-8 encoding; this issue is only present in Serverless Launch because Express.js (used by TAP Launcher) added it itself.