### PR TITLE
HbbTV2 Fixes

### DIFF
--- a/hbbtv2/doctype
+++ b/hbbtv2/doctype
@@ -1,1 +1,0 @@
-<!DOCTYPE html PUBLIC "-//HbbTV//1.2.1//EN" "http://www.hbbtv.org/dtd/HbbTV-1.2.1.dtd">

--- a/hbbtv2/mimetype
+++ b/hbbtv2/mimetype
@@ -1,1 +1,0 @@
-text/html; charset=utf-8

--- a/hbbtv2/mimetype
+++ b/hbbtv2/mimetype
@@ -1,1 +1,1 @@
-application/vnd.hbbtv.xhtml+xml; charset=utf-8
+text/html; charset=utf-8

--- a/hbbtv2/rootelement
+++ b/hbbtv2/rootelement
@@ -1,1 +1,0 @@
-<html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
* Mime type, doctype and root element no longer required. These were just requirements in earlier specs.