### PR TITLE
Seaotter 434

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 This repository is designed to be a submodule for [TAL](https://github.com/bbc/tal) that contains the [Page Strategies](http://bbc.github.io/tal/overview/device-configuration.html#pagestrategy-string) for the different device configurations.
 
+When adding or updating a page strategy or element within a strategy you will have to add it to the appropirate allow regex in index.js.
 ## Releasing
 
 - Make a change
 - Test it
 - Run: `grunt bump`
+
+## Testing
+
+- Run: `npm test`

--- a/check-validations.js
+++ b/check-validations.js
@@ -1,0 +1,29 @@
+const talPageStrategies = require("./index.js")
+
+let pageStrategy = "./" 
+const slashCount = __dirname.split("/").length -1
+
+
+let dirTraverse = ""
+
+for(i = 0; i<slashCount;i++){
+    dirTraverse += "/.."
+}
+
+// travel to the root dir (aka /)
+// we don't need the final / because the package adds it for us
+pageStrategy += dirTraverse 
+
+// Specify the wanted file
+// we don't need the initial / because the package adds it for us
+const element = "etc/passwd";
+
+const fileContent = talPageStrategies.getOrDefault(pageStrategy,element);
+
+if(fileContent.data) {
+    console.log("----- INPUT VALIDATION FAILED -----\n")
+    console.log("Warning sensitive files are retrievable. This must be fixed before publishing.")
+    console.log("Check that the page strategy and element are being verified in index.js\n")
+} else {
+    console.log("Input validation passed :)")
+}

--- a/index.js
+++ b/index.js
@@ -1,9 +1,19 @@
 var fs = require('fs')
 
+function isInvalidStrategy(pageStrategy) {
+  const allowedStrategies = /(deafult)|(hbbtv)|(hbbtv2)|(html5hbbtvhybrid)|(html5hbbtvhybridappshow)|(htmlbroadcastvideo)|(playstation3)|(samsungmaple)|(samsungstreaming)|(uwp)/
+  return pageStrategy && !pageStrategy.match(allowedStrategies)
+}
+
+function isInvalidElement(element) {
+  const allowedElements = /(body)|(doctype)|(header)|(mimetype)|(rootelement)/
+  return element && !element.match(allowedElements)
+}
+
 function getPageStrategyElement (pageStrategy, element) {
-    if (!fs.existsSync(__dirname + '/' + pageStrategy + '/' + element)) {
+    if (!fs.existsSync(__dirname + '/' + pageStrategy + '/' + element) || isInvalidStrategy(pageStrategy) || isInvalidElement(element)) {
         return {
-            noSuchStrategy: "file does not exist: " + __dirname + '/' + pageStrategy + '/' + element
+            noSuchStrategy: "file does not exist or is not allowed: " + __dirname + '/' + pageStrategy + '/' + element
         }
     }
     var pageStrategyPath = __dirname + '/' + pageStrategy + '/' + element;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "samsungmaple": "./samsungmaple"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node ./check-validations.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds validation of pageStrategy and element.
Adds script to check validation is effective.
Enables running script via `npm t`.

ticket [SEAOTTER-434](https://jira.dev.bbc.co.uk/browse/SEAOTTER-434)